### PR TITLE
fix(docker): remove bundled npm from runtime image (clears 12 Trivy alerts)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN apk add --no-cache dumb-init
 COPY package.json yarn.lock ./
 RUN yarn install --production --frozen-lockfile && yarn cache clean
 
+# Remove the npm CLI bundled in the base image; it is not used at runtime
+# (the app runs via yarn) and its bundled deps trigger Trivy CVE alerts.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+
 COPY --from=builder /excalidraw-room/dist ./dist
 
 # Health check


### PR DESCRIPTION
Åtgärdar samtliga 12 öppna code-scanning-varningar (Trivy).

## Bakgrund
Alla 12 varningar sitter i `/usr/local/lib/node_modules/npm/node_modules/{tar,brace-expansion,undici}` — dvs. den `npm` som följer med basimagen `node:24-alpine`, **inte** appens kod eller `yarn.lock`.

Runtime-imagen kör appen via `yarn` (`node dist/index.js`) och använder aldrig npm. npm låg bara kvar som skräp från basimagen.

## Ändring
Tar bort npm/npx ur runtime-stage:t i Dockerfile:
```dockerfile
RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
```

## Verifierat lokalt
- Imagen byggs utan fel.
- npm + npx borta; yarn + node kvar.
- `yarn start` startar appen (`node dist/index.js` körs; avslutas endast pga saknad DRAGONFLY_MASTER_HOST, samma som orörd image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)